### PR TITLE
Add Multi-Ecosystem updates to Dependabot.yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,19 @@
 ---
 version: 2
 updates:
+  - name: "Multi-Ecosystem dependencies"
+    package-ecosystems:
+      - package-ecosystem: "github-actions"
+        pattern: ["first-interaction"]
+        directory: "/"
+      - package-ecosystem: npm
+        pattern: ["lodash"]
+        directory: "/javascript"
+      - package-ecosystem: bundler
+        pattern: ["business"]
+        directory: "/ruby"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This pull request changes the configuration file to include updates for multiple ecosystems.  The grouped packages include:
- GitHub Action package [first-interactions](https://github.com/actions/first-interaction)
- Ruby Gem package [business](https://rubygems.org/gems/business)
- Npm package [lodash](https://www.npmjs.com/package/lodash)